### PR TITLE
refactor(core): eliminate MaterialApp nesting with unified app structure

### DIFF
--- a/flutter_mana_kits/lib/src/plugins/mana_memory_info/widgets/memory_info_content.dart
+++ b/flutter_mana_kits/lib/src/plugins/mana_memory_info/widgets/memory_info_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_mana/flutter_mana.dart';
 import 'package:flutter_mana_kits/src/i18n/i18n_mixin.dart';
 import 'package:flutter_mana_kits/src/icons/kit_icons.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -219,10 +220,9 @@ class _MemoryInfoContentState extends State<MemoryInfoContent> with I18nMixin {
                 final isEven = index.isOdd;
 
                 return InkWell(
-                  onTap: () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => MemoryDetail(detail: item, service: _memoryService),
-                    ),
+                  onTap: () => ManaNavigator.pushMaterial(
+                    context,
+                    MemoryDetail(detail: item, service: _memoryService),
                   ),
                   child: Container(
                     color: isEven ? Colors.grey.shade100 : Colors.white,

--- a/flutter_mana_kits/lib/src/plugins/mana_widget_info_inspector/widgets/widget_info_inspector_content.dart
+++ b/flutter_mana_kits/lib/src/plugins/mana_widget_info_inspector/widgets/widget_info_inspector_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_mana/flutter_mana.dart';
 import 'package:flutter_mana_kits/src/i18n/i18n_mixin.dart';
 import 'package:flutter_mana_kits/src/icons/kit_icons.dart';
 
@@ -55,12 +56,9 @@ class _WidgetInfoInspectorContentState extends State<WidgetInfoInspectorContent>
                 onPressed: widget.selection.currentElement == null
                     ? null
                     : () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (ctx) {
-                              return InfoPage(elements: widget.selection.currentElement!.debugGetDiagnosticChain());
-                            },
-                          ),
+                        ManaNavigator.pushMaterial(
+                          context,
+                          InfoPage(elements: widget.selection.currentElement!.debugGetDiagnosticChain()),
                         );
                       },
                 constraints: const BoxConstraints(),

--- a/flutter_mana_kits/lib/src/plugins/mana_widget_info_inspector/widgets/widget_info_inspector_detail.dart
+++ b/flutter_mana_kits/lib/src/plugins/mana_widget_info_inspector/widgets/widget_info_inspector_detail.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_mana/flutter_mana.dart';
 import 'package:flutter_mana_kits/src/icons/kit_icons.dart';
 
 /// 用于封装每个 Element 及其随机颜色信息
@@ -76,19 +77,18 @@ class _InfoPageState extends State<InfoPage> {
 
   /// 页面跳转至详情页
   void _navigateToDetail(Element element) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => Scaffold(
+    ManaNavigator.pushMaterial(
+      context,
+      Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          elevation: 0.0,
           backgroundColor: Colors.white,
-          appBar: AppBar(
-            elevation: 0.0,
-            backgroundColor: Colors.white,
-            shadowColor: Colors.transparent,
-            surfaceTintColor: Colors.transparent,
-            title: const Text("Widget Detail"),
-          ),
-          body: _ElementDetailPage(element: element),
+          shadowColor: Colors.transparent,
+          surfaceTintColor: Colors.transparent,
+          title: const Text("Widget Detail"),
         ),
+        body: _ElementDetailPage(element: element),
       ),
     );
   }
@@ -102,7 +102,9 @@ class _InfoPageState extends State<InfoPage> {
     }
     final RegExp reg = RegExp(query, caseSensitive: false);
     setState(() {
-      _filteredList = _originalList.where((item) => reg.hasMatch(item.element.widget.toStringShort())).toList();
+      _filteredList = _originalList
+          .where((item) => reg.hasMatch(item.element.widget.toStringShort()))
+          .toList();
     });
   }
 
@@ -150,9 +152,11 @@ class _InfoPageState extends State<InfoPage> {
               onChanged: _onSearchChanged,
               decoration: InputDecoration(
                 hintText: 'Search widget',
-                border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                border:
+                    OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
                 prefixIcon: const Icon(KitIcons.search),
-                suffixIcon: InkWell(onTap: _clear, child: const Icon(KitIcons.close)),
+                suffixIcon:
+                    InkWell(onTap: _clear, child: const Icon(KitIcons.close)),
                 isDense: true,
               ),
             ),
@@ -165,7 +169,8 @@ class _InfoPageState extends State<InfoPage> {
                   : ListView.builder(
                       physics: const BouncingScrollPhysics(),
                       itemCount: _filteredList.length,
-                      itemBuilder: (_, index) => _buildItem(_filteredList[index]),
+                      itemBuilder: (_, index) =>
+                          _buildItem(_filteredList[index]),
                     ),
             ),
           ),

--- a/lib/flutter_mana.dart
+++ b/lib/flutter_mana.dart
@@ -11,4 +11,7 @@ export 'src/services/vm_inspector.dart' show VmInspector;
 export 'src/services/vm_inspector_mixin.dart' show VmInspectorMixin;
 export 'src/utils/hit_test_utils.dart' show HitTestUtils;
 export 'src/widgets/check_icon_button.dart' show CheckIconButton;
-export 'src/widgets/floating_window/index.dart' show ManaFloatingWindow, PositionType;
+export 'src/widgets/floating_window/index.dart'
+    show ManaFloatingWindow, PositionType;
+export 'src/widgets/mana_navigator.dart'
+    show ManaNavigator, ManaHitTestForwarder, ManaHitTestManager;

--- a/lib/src/core/mana_widget.dart
+++ b/lib/src/core/mana_widget.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
+import '../../flutter_mana.dart';
 import '../widgets/mana_overlay.dart';
-import 'mana_plugin_manager.dart';
-import 'mana_store.dart';
 
 /// A global key used to access the root node of the ManaWidget.
 ///
@@ -15,7 +14,7 @@ Locale manaLocale = Locale('en');
 /// Provides the entry point and basic structure for the Mana plugin system.
 ///
 /// 提供了 Mana 插件体系的入口和基础结构。
-class ManaWidget extends StatelessWidget {
+class ManaWidget extends StatefulWidget {
   /// The child widget of ManaWidget.
   ///
   /// ManaWidget 的子组件。
@@ -33,12 +32,27 @@ class ManaWidget extends StatelessWidget {
   /// 构造函数，用于创建 ManaWidget 实例。
   const ManaWidget({super.key, required this.child, this.enable = true});
 
+  @override
+  State<ManaWidget> createState() => _ManaWidgetState();
+}
+
+class _ManaWidgetState extends State<ManaWidget> {
+  /// 初始化 Future，用于 FutureBuilder
+  late final Future<ManaState> _initializationFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializationFuture = _initialize();
+  }
+
   /// Initializes the Mana store.
   ///
-  /// 初始化 Mana 存储。
-  Future<void> _initialize() async {
+  /// 初始化 Mana 存储 。
+  Future<ManaState> _initialize() async {
     await ManaStore.instance.init();
     await ManaPluginManager.instance.initialize();
+    return ManaStore.instance.getManaState();
   }
 
   @override
@@ -46,8 +60,8 @@ class ManaWidget extends StatelessWidget {
     /// If `enable` is `false`, return the child widget directly without loading Mana-related features.
     ///
     /// 如果 `enable` 为 `false`，则直接返回子组件，不加载 Mana 相关功能。
-    if (!enable) {
-      return child;
+    if (!widget.enable) {
+      return widget.child;
     }
 
     // Get the platform dispatcher to access locale information for internationalization.
@@ -57,49 +71,55 @@ class ManaWidget extends StatelessWidget {
     // 获取第一个首选区域设置，用于显示本地化的插件名称。
     manaLocale = platformDispatcher.locales.first;
 
-    /// 在经过多种方案尝试后，只有在这嵌套一层MaterialApp是侵入性最小、功能完善最好的方案，其他方案多多少少有瑕疵。
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('en', 'US'),
-        Locale('zh', 'CN'),
-      ],
-      home: Stack(
-        children: [
-          /// Wraps the child widget with RepaintBoundary and assigns `manaRootKey` to it.
-          ///
-          /// 使用 RepaintBoundary 包裹子组件，并为其分配 `manaRootKey`。
-          RepaintBoundary(key: manaRootKey, child: child),
+    return Stack(
+      textDirection: TextDirection.ltr,
+      children: [
+        /// Wraps the child widget with RepaintBoundary and assigns `manaRootKey` to it.
+        ///
+        /// 使用 RepaintBoundary 包裹子组件，并为其分配 `manaRootKey`。
+        RepaintBoundary(key: manaRootKey, child: widget.child),
 
-          /// Uses FutureBuilder to display ManaOverlay after the Mana store is initialized.
-          ///
-          /// 使用 FutureBuilder 在 Mana 存储初始化完成后显示 ManaOverlay。
-          FutureBuilder<void>(
-            future: _initialize(),
-            builder: (context, snapshot) {
-              /// If initialization is not complete, return a shrink-wrapped box to avoid displaying content during loading.
-              ///
-              /// 如果初始化未完成，则返回一个空盒子，避免在加载时显示内容。
-              if (snapshot.connectionState != ConnectionState.done) {
-                return const SizedBox.shrink();
-              }
-
-              /// After initialization is complete, display the ManaOverlay.
-              ///
-              /// 初始化完成后，显示 ManaOverlay。
-              return const Material(
+        // 使用 FutureBuilder 实现异步初始化，更简洁
+        FutureBuilder<ManaState>(
+          future: _initializationFuture,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const SizedBox.shrink();
+            }
+            final mana = ManaScope(
+              state: snapshot.data!,
+              child: ManaHitTestForwarder(
+                child: ManaNavigator(
+                  onGenerateRoute: (settings) => PageRouteBuilder(
+                    pageBuilder: (context, animation, secondaryAnimation) =>
+                        ManaOverlay(),
+                    transitionDuration: Duration.zero,
+                    reverseTransitionDuration: Duration.zero,
+                  ),
+                ),
+              ),
+            );
+            return Material(
                 type: MaterialType.transparency,
-                child: ManaOverlay(),
-              );
-            },
-          ),
-        ],
-      ),
+                child: Directionality(
+                  textDirection: TextDirection.ltr,
+                  child: Localizations(
+                    delegates: [
+                      GlobalCupertinoLocalizations.delegate,
+                      GlobalMaterialLocalizations.delegate,
+                      GlobalWidgetsLocalizations.delegate,
+                    ],
+                    locale: manaLocale,
+                    child: ScaffoldMessenger(
+                      child: DefaultTextEditingShortcuts(
+                        child: mana,
+                      ),
+                    ),
+                  ),
+                ));
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/src/widgets/floating_window/widget.dart
+++ b/lib/src/widgets/floating_window/widget.dart
@@ -114,8 +114,9 @@ class _FloatingWindowState extends State<FloatingWindow> {
   }
 
   Widget _buildContent(Size screenSize, Size windowSize, bool fullscreen) {
-    final radius =
-        (fullscreen || widget.initialHeight == double.infinity) ? BorderRadius.zero : BorderRadius.circular(8);
+    final radius = (fullscreen || widget.initialHeight == double.infinity)
+        ? BorderRadius.zero
+        : BorderRadius.circular(8);
 
     return Container(
       clipBehavior: Clip.antiAlias,
@@ -178,53 +179,46 @@ class _FloatingWindowState extends State<FloatingWindow> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false, // 拦截返回
-      onPopInvokedWithResult: (bool didPop, void result) {
-        if (!didPop) {
-          if (_controller.manaState.activePluginName.value.isEmpty) {
-            _controller.manaState.pluginManagementPanelVisible.value = false;
-            return;
-          }
-          _controller.manaState.floatWindowMainVisible.value = false;
-          _controller.manaState.floatingButtonVisible.value = true;
-        }
-      },
-      child: Stack(
-        children: [
-          if (widget.showBarrier) _buildBarrier(),
-          if (widget.content != null)
-            AnimatedBuilder(
-              animation: Listenable.merge([
-                _controller.manaState.floatWindowMainVisible,
-                _controller.fullscreen,
-                _controller.offset,
-              ]), // 合并多个 ValueListenable
-              builder: (context, _) {
-                final visible = _controller.manaState.floatWindowMainVisible.value;
-                final fullscreen = _controller.fullscreen.value;
-                final offset = _controller.offset.value;
-                final double currentLeft = fullscreen ? 0 : offset.dx;
-                final double currentTop = fullscreen ? 0 : offset.dy;
-                final double currentWidth = fullscreen ? _controller.screenSize.width : _controller.windowSize.width;
-                final double currentHeight = fullscreen ? _controller.screenSize.height : _controller.windowSize.height;
-                return Positioned(
-                  left: currentLeft,
-                  top: currentTop,
-                  width: currentWidth,
-                  height: currentHeight,
-                  child: Visibility(
-                    visible: visible,
-                    replacement: nil,
-                    maintainState: widget.maintainContent,
-                    maintainAnimation: widget.maintainContent,
-                    child: _buildContent(_controller.screenSize, _controller.windowSize, fullscreen),
-                  ),
-                );
-              },
-            ),
-        ],
-      ),
+    return Stack(
+      children: [
+        if (widget.showBarrier) _buildBarrier(),
+        if (widget.content != null)
+          AnimatedBuilder(
+            animation: Listenable.merge([
+              _controller.manaState.floatWindowMainVisible,
+              _controller.fullscreen,
+              _controller.offset,
+            ]), // 合并多个 ValueListenable
+            builder: (context, _) {
+              final visible =
+                  _controller.manaState.floatWindowMainVisible.value;
+              final fullscreen = _controller.fullscreen.value;
+              final offset = _controller.offset.value;
+              final double currentLeft = fullscreen ? 0 : offset.dx;
+              final double currentTop = fullscreen ? 0 : offset.dy;
+              final double currentWidth = fullscreen
+                  ? _controller.screenSize.width
+                  : _controller.windowSize.width;
+              final double currentHeight = fullscreen
+                  ? _controller.screenSize.height
+                  : _controller.windowSize.height;
+              return Positioned(
+                left: currentLeft,
+                top: currentTop,
+                width: currentWidth,
+                height: currentHeight,
+                child: Visibility(
+                  visible: visible,
+                  replacement: nil,
+                  maintainState: widget.maintainContent,
+                  maintainAnimation: widget.maintainContent,
+                  child: _buildContent(_controller.screenSize,
+                      _controller.windowSize, fullscreen),
+                ),
+              );
+            },
+          ),
+      ],
     );
   }
 }

--- a/lib/src/widgets/mana_navigator.dart
+++ b/lib/src/widgets/mana_navigator.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_mana/flutter_mana.dart';
+
+/// A Navigator wrapper that automatically wraps all pushed pages with ManaHitTestManager.
+///
+/// This ensures that all pages pushed through this navigator have event passthrough capability.
+///
+/// 自动为所有 push 的页面包裹 ManaHitTestManager 的 Navigator 包装器。
+/// 这确保了通过这个 navigator 推送的所有页面都具备事件穿透能力。
+class ManaNavigator extends StatefulWidget {
+  final GlobalKey<NavigatorState>? navigatorKey;
+  final String? initialRoute;
+  final RouteFactory? onGenerateRoute;
+  final RouteFactory? onUnknownRoute;
+  final List<NavigatorObserver>? observers;
+  final String? restorationScopeId;
+
+  const ManaNavigator({
+    super.key,
+    this.navigatorKey,
+    this.initialRoute,
+    this.onGenerateRoute,
+    this.onUnknownRoute,
+    this.observers,
+    this.restorationScopeId,
+  });
+
+  @override
+  State<ManaNavigator> createState() => _ManaNavigatorState();
+
+  /// Push a route with automatic ManaHitTestManager wrapping
+  static Future<T?> pushMaterial<T extends Object?>(
+    BuildContext context,
+    Widget page, {
+    RouteSettings? settings,
+    bool fullscreenDialog = false,
+    bool maintainState = true,
+  }) {
+    return Navigator.of(context).push<T>(
+      MaterialPageRoute<T>(
+        settings: settings,
+        fullscreenDialog: fullscreenDialog,
+        maintainState: maintainState,
+        builder: (context) => ManaHitTestManager(child: page),
+      ),
+    );
+  }
+
+  /// Push a named route with automatic ManaHitTestManager wrapping
+  static Future<T?> pushNamed<T extends Object?>(
+    BuildContext context,
+    String routeName, {
+    Object? arguments,
+  }) {
+    return Navigator.of(context).pushNamed<T>(
+      routeName,
+      arguments: arguments,
+    );
+  }
+
+  /// Push a CupertinoPageRoute with automatic ManaHitTestManager wrapping
+  static Future<T?> pushCupertino<T extends Object?>(
+    BuildContext context,
+    Widget page, {
+    RouteSettings? settings,
+    bool fullscreenDialog = false,
+    bool maintainState = true,
+  }) {
+    return Navigator.of(context).push<T>(
+      _ManaCupertinoPageRoute<T>(
+        settings: settings,
+        fullscreenDialog: fullscreenDialog,
+        maintainState: maintainState,
+        builder: (context) => ManaHitTestManager(child: page),
+      ),
+    );
+  }
+}
+
+class _ManaNavigatorState extends State<ManaNavigator>
+    with WidgetsBindingObserver {
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+
+  @override
+  Future<bool> didPopRoute() async {
+    final navigatorKey = widget.navigatorKey ?? _navigatorKey;
+    if ((await navigatorKey.currentState?.maybePop()) ?? false) {
+      return true;
+    }
+    if (!mounted) return false;
+    final manaState = ManaScope.of(context);
+    if (manaState.pluginManagementPanelVisible.value) {
+      manaState.pluginManagementPanelVisible.value = false;
+      return true;
+    }
+    if (manaState.floatWindowMainVisible.value) {
+      manaState.floatWindowMainVisible.value = false;
+      manaState.floatingButtonVisible.value = true;
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  void initState() {
+    WidgetsBinding.instance.addObserver(this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: widget.navigatorKey ?? _navigatorKey,
+      initialRoute: widget.initialRoute,
+      onGenerateRoute: (settings) {
+        // 如果提供了自定义的 onGenerateRoute，先调用它
+        final route = widget.onGenerateRoute?.call(settings);
+        if (route != null) {
+          // 包装路由的 builder，自动添加 ManaHitTestManager
+          if (route is MaterialPageRoute) {
+            return MaterialPageRoute(
+              settings: route.settings,
+              fullscreenDialog: route.fullscreenDialog,
+              maintainState: route.maintainState,
+              builder: (context) => ManaHitTestManager(
+                child: route.builder(context),
+              ),
+            );
+          } else if (route is CupertinoPageRoute) {
+            return _ManaCupertinoPageRoute(
+              settings: route.settings,
+              fullscreenDialog: route.fullscreenDialog,
+              maintainState: route.maintainState,
+              builder: (context) => ManaHitTestManager(
+                child: route.builder(context),
+              ),
+            );
+          } else if (route is PageRouteBuilder) {
+            return PageRouteBuilder(
+              settings: route.settings,
+              opaque: route.opaque,
+              barrierDismissible: route.barrierDismissible,
+              barrierColor: route.barrierColor,
+              barrierLabel: route.barrierLabel,
+              maintainState: route.maintainState,
+              fullscreenDialog: route.fullscreenDialog,
+              pageBuilder: (context, animation, secondaryAnimation) {
+                return ManaHitTestManager(
+                  child:
+                      route.pageBuilder(context, animation, secondaryAnimation),
+                );
+              },
+              transitionsBuilder: route.transitionsBuilder,
+              transitionDuration: route.transitionDuration,
+              reverseTransitionDuration: route.reverseTransitionDuration,
+            );
+          }
+        }
+        return route;
+      },
+      onUnknownRoute: widget.onUnknownRoute,
+      observers: widget.observers ?? [],
+      restorationScopeId: widget.restorationScopeId,
+    );
+  }
+}
+
+class _ManaCupertinoPageRoute<T> extends CupertinoPageRoute<T> {
+  /// Creates a page route for use in an iOS designed app.
+  ///
+  /// The [builder], [maintainState], and [fullscreenDialog] arguments must not
+  /// be null.
+  _ManaCupertinoPageRoute({
+    required super.builder,
+    super.title,
+    super.settings,
+    super.requestFocus,
+    super.maintainState = true,
+    super.fullscreenDialog,
+    super.allowSnapshotting = true,
+    super.barrierDismissible = false,
+  }) {
+    assert(opaque);
+  }
+
+  @override
+  Widget buildTransitions(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child) {
+    return ManaHitTestManager(
+        child: super
+            .buildTransitions(context, animation, secondaryAnimation, child));
+  }
+}
+
+class ManaHitTestManager extends StatefulWidget {
+  // 使用 Set 来避免重复的 key，并添加同步保护
+  static final Set<GlobalKey> _keys = <GlobalKey>{};
+
+  // 提供只读访问
+  static Set<GlobalKey> get keys => Set.unmodifiable(_keys);
+
+  // 线程安全的 key 管理方法
+  static void _addKey(GlobalKey key) {
+    _keys.add(key);
+  }
+
+  static void _removeKey(GlobalKey key) {
+    _keys.remove(key);
+  }
+
+  final Widget child;
+  const ManaHitTestManager({super.key, required this.child});
+
+  @override
+  State<ManaHitTestManager> createState() => _ManaHitTestManagerState();
+}
+
+class _ManaHitTestManagerState extends State<ManaHitTestManager> {
+  GlobalKey? _key;
+
+  @override
+  void initState() {
+    // 查找最外层的 ManaHitTestManager 的 key
+    _key =
+        context.findRootAncestorStateOfType<_ManaHitTestManagerState>()?._key;
+
+    // 如果没有找到父级的 key，说明这是最外层，创建新的 key
+    if (_key == null) {
+      _key = GlobalKey();
+      ManaHitTestManager._addKey(_key!);
+    } else {
+      _key = null;
+    }
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    // 只有当这个实例拥有 key 时才移除（即最外层实例）
+    if (_key != null && ManaHitTestManager.keys.contains(_key!)) {
+      ManaHitTestManager._removeKey(_key!);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_key != null) {
+      return SizedBox(
+        key: _key,
+        child: widget.child,
+      );
+    }
+    return widget.child;
+  }
+}
+
+class ManaHitTestForwarder extends SingleChildRenderObjectWidget {
+  const ManaHitTestForwarder({
+    super.key,
+    super.child,
+  });
+
+  @override
+  RenderManaHitTestForwarder createRenderObject(BuildContext context) {
+    return RenderManaHitTestForwarder(context);
+  }
+}
+
+class RenderManaHitTestForwarder extends RenderProxyBox {
+  final BuildContext context;
+  RenderManaHitTestForwarder(this.context);
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    // 转换为 List 以使用 reversed 方法
+    for (final key in ManaHitTestManager.keys.toList().reversed) {
+      if (key.currentContext?.findRenderObject()
+          case RenderBox renderManaHitTestForwarder) {
+        final hit =
+            renderManaHitTestForwarder.hitTest(result, position: position);
+        if (hit) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/lib/src/widgets/mana_overlay.dart
+++ b/lib/src/widgets/mana_overlay.dart
@@ -22,21 +22,9 @@ class ManaOverlay extends StatefulWidget {
 }
 
 class _ManaOverlayState extends State<ManaOverlay> {
-  /// The state object for Mana, which must be preserved using a StatefulWidget.
-  ///
-  /// Mana 的状态对象，必须使用 StatefulWidget 进行状态保存。
-  final ManaState _manaState = ManaStore.instance.getManaState();
 
   @override
-  void dispose() {
-    _manaState.dispose();
-    super.dispose();
-  }
-
-  /// Builds the stack of overlay widgets.
-  ///
-  /// 构建覆盖层小部件的堆栈。
-  Widget _buildStack() {
+  Widget build(BuildContext context) {
     return Builder(
       builder: (BuildContext context) {
         // Access the ManaState from the context.
@@ -49,8 +37,9 @@ class _ManaOverlayState extends State<ManaOverlay> {
             ValueListenableBuilder(
               valueListenable: manaState.activePluginName,
               builder: (context, value, _) {
-                final currentActivatedPluginWidget =
-                    ManaPluginManager.instance.pluginsMap[manaState.activePluginName.value]?.buildWidget(context);
+                final currentActivatedPluginWidget = ManaPluginManager
+                    .instance.pluginsMap[manaState.activePluginName.value]
+                    ?.buildWidget(context);
                 return currentActivatedPluginWidget ?? nilPosition;
               },
             ),
@@ -75,14 +64,6 @@ class _ManaOverlayState extends State<ManaOverlay> {
           ],
         );
       },
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ManaScope(
-      state: _manaState,
-      child: _buildStack(),
     );
   }
 }


### PR DESCRIPTION
- Remove double MaterialApp to fix InheritedWidget inheritance
- Replace with ManaNavigator + essential wrappers
- Resolves nested app structure issues